### PR TITLE
Add react-native-gutenberg-bridge to list of libraries to cleanup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 ruby File.read('.ruby-version').strip
 
 gem "dotenv"
+gem "psych"
 
 group :dev do
   gem "yard"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,7 @@ GEM
     diff-lcs (1.4.4)
     dotenv (2.7.6)
     hashdiff (1.0.1)
+    psych (3.3.1)
     public_suffix (4.0.6)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
@@ -32,6 +33,7 @@ PLATFORMS
 
 DEPENDENCIES
   dotenv
+  psych
   rspec
   webmock
   yard

--- a/bin/bintray_garbage_collector.rb
+++ b/bin/bintray_garbage_collector.rb
@@ -1,4 +1,5 @@
 require 'dotenv'
+require 'optparse'
 require 'psych'
 require_relative '../lib/garbage_collector.rb'
 
@@ -6,6 +7,24 @@ source = Psych.load(File.read('projects.yml'), symbolize_names: true)
 projects = source[:projects]
 
 Dotenv.load
+
+# Default options
+options = {
+  verbose: true,
+  dry_run: false
+}
+
+OptionParser.new do |parser|
+  parser.banner = "Usage: #{File.basename(__FILE__)} [options]"
+
+  parser.on("-v", "--[no-]verbose", "Run verbosely") do |v|
+    options[:verbose] = v
+  end
+
+  parser.on('-d', '--dry-run', "Dry run") do
+    options[:dry_run] = true
+  end
+end.parse!
 
 def read_from_environment!(key)
   value = ENV[key]
@@ -17,6 +36,6 @@ end
 GarbageCollector.new(
   bintray_user: read_from_environment!('BINTRAY_USER'),
   bintray_key: read_from_environment!('BINTRAY_KEY'),
-  verbose: true,
-  dry_run: false
+  verbose: options[:verbose],
+  dry_run: options[:dry_run]
 ).run(projects)

--- a/bin/bintray_garbage_collector.rb
+++ b/bin/bintray_garbage_collector.rb
@@ -1,10 +1,9 @@
 require 'dotenv'
+require 'psych'
 require_relative '../lib/garbage_collector.rb'
 
-# We might want to extract this in a file to make it easier to edit
-projects = [
-  { bintray: 'wordpress-mobile/maven/utils', github: 'wordpress-mobile/WordPress-Utils-Android' }
-]
+source = Psych.load(File.read('projects.yml'), symbolize_names: true)
+projects = source[:projects]
 
 Dotenv.load
 

--- a/lib/garbage_collector.rb
+++ b/lib/garbage_collector.rb
@@ -24,13 +24,16 @@ class GarbageCollector
   #
   # @param projects [Array] the array of +Hash+ projects on which to run the garbage collection
   def run(projects)
+    projects_not_found = []
+
     projects.each do |project|
       log "Looking for versions to delete for #{project[:bintray]}..."
 
       dev_versions = @bintray.get_bintray_versions(project: project[:bintray])
 
       if dev_versions.nil?
-        log "> Project not found. Aborting."
+        log "> Project not found."
+        projects_not_found.push(project)
         next
       end
 
@@ -65,11 +68,17 @@ class GarbageCollector
         end
       end
     end
+
+    unless projects_not_found.empty?
+      log("\nGarbage collection was unsuccessful. Could not find projects:", forced: true)
+      projects_not_found.each { |p| log("> #{p[:bintray]}", forced: true) }
+      exit 1
+    end
   end
 
   private
 
-  def log(message)
-    puts message if @verbose
+  def log(message, forced: false)
+    puts message if @verbose || forced
   end
 end

--- a/lib/garbage_collector.rb
+++ b/lib/garbage_collector.rb
@@ -29,6 +29,11 @@ class GarbageCollector
 
       dev_versions = @bintray.get_bintray_versions(project: project[:bintray])
 
+      if dev_versions.nil?
+        log "> Project not found. Aborting."
+        next
+      end
+
       if dev_versions.empty?
         log "> No versions found. Moving on."
         next

--- a/projects.yml
+++ b/projects.yml
@@ -1,4 +1,7 @@
 projects:
+  - name: Gutenberg Mobile
+    bintray: wordpress-mobile/maven/react-native-gutenberg-bridge
+    github: wordpress-mobile/gutenberg-mobile
   - name: WordPress Utils
     bintray: wordpress-mobile/maven/utils
     github: wordpress-mobile/WordPress-Utils-Android

--- a/projects.yml
+++ b/projects.yml
@@ -1,0 +1,4 @@
+projects:
+  - name: WordPress Utils
+    bintray: wordpress-mobile/maven/utils
+    github: wordpress-mobile/WordPress-Utils-Android

--- a/spec/integration/garbage_collector_spec.rb
+++ b/spec/integration/garbage_collector_spec.rb
@@ -11,7 +11,12 @@ RSpec.describe GarbageCollector do
     expect_any_instance_of(BintrayClient).to receive(:get_bintray_versions)
       .and_return(nil)
 
-    gb.run(projects)
+    # Capture the standard output to ensure the user would see a message and to
+    # have a clean RSpec output. Not interested in the message content itself.
+    expect(STDOUT).to receive(:puts).at_least(1).times
+    expect { gb.run(projects) }.to raise_error(SystemExit) do |error|
+      expect(error.status).to eq(1)
+    end
   end
 
   it 'requests to delete all the Bintray version for closed PRs' do

--- a/spec/integration/garbage_collector_spec.rb
+++ b/spec/integration/garbage_collector_spec.rb
@@ -2,6 +2,18 @@ require 'garbage_collector'
 
 RSpec.describe GarbageCollector do
 
+  it 'fails gracefully when a Bintray project cannot be found' do
+    gb = GarbageCollector.new(bintray_user: 'user', bintray_key: 'key')
+    projects = [
+      { bintray: 'bt_project_name_1', github: 'gh_project_name_1' },
+    ]
+
+    expect_any_instance_of(BintrayClient).to receive(:get_bintray_versions)
+      .and_return(nil)
+
+    gb.run(projects)
+  end
+
   it 'requests to delete all the Bintray version for closed PRs' do
     gb = GarbageCollector.new(bintray_user: 'user', bintray_key: 'key')
     projects = [


### PR DESCRIPTION
Even though we won't be using Bintray for long, I still took the time to add the `react-native-gutenberg-bridge` library to the list of projects to garbage collect.

I think we should be able to easily add an `S3Client` alongside the Bintray one and keep using this tool to garbage collect the bucket.

While I was there, I took the time to add CLI options for dry run and verbose output and fixed a bug I discovered along the way.